### PR TITLE
Fortio install for CI

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -95,6 +95,8 @@ jobs:
         # (you'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else)
         sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
         export PATH=$PATH:/usr/local/kubebuilder/bin
+    - name: Get Fortio
+      run: go get fortio.org/fortio
     - name: Test With Coverage
       run: go test -gcflags=-l -v  -coverprofile=coverage.txt -covermode=atomic ./...
     - name: Upload coverage to Codecov


### PR DESCRIPTION
Signed-off-by: Srinivasan Parthasarathy <5309125+sriumcp@users.noreply.github.com>

CI workflow is [currently failing](https://github.com/iter8-tools/handler/runs/2737921933?check_suite_focus=true). The fix is to install Fortio before running the tests... since Fortio is used during the tests. This PR accomplishes this.