### PR TITLE
common/bash task

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -50,10 +50,10 @@ jobs:
       run: |
         export COVERAGE=$(go tool cover -func coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
         echo "code coverage is at ${COVERAGE}"
-        if [ 1 -eq "$(echo "${COVERAGE} > 74.0" | bc)" ]; then \
-          echo "all good... coverage is at or above 74.0%"; 
+        if [ 1 -eq "$(echo "${COVERAGE} > 76.0" | bc)" ]; then \
+          echo "all good... coverage is at or above 76.0%"; 
         else \
-          echo "not good... coverage is not at 74.0% or above";
+          echo "not good... coverage is not at 76.0% or above";
           exit 1
         fi        
     - name: Get golint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+IMG ?= handler:latest
+
+# Before pushing, `make` or `make all` will run through most of the build tests
+all: lint vet test coverage
+
+lint:
+	golint ./...
+
+vet:
+	go vet ./...
+
+test:
+	go test ./... -coverprofile=coverage.out
+
+coverage:
+	@echo "test coverage: $(shell go tool cover -func coverage.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}')"
+
+docker-build:
+	docker build . -t ${IMG}
+
+docker-push:
+	docker push ${IMG}

--- a/base/base.go
+++ b/base/base.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"html/template"
 
+	"github.com/iter8-tools/etc3/api/v2alpha2"
 	"github.com/iter8-tools/handler/utils"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var log *logrus.Logger
@@ -44,7 +46,68 @@ func (a *Action) Run(ctx context.Context) error {
 
 // Tags supports string extrapolation using tags.
 type Tags struct {
-	M map[string]string
+	M map[string]interface{}
+}
+
+// NewTags creates an empty instance of Tags
+func NewTags() Tags {
+	return Tags{M: make(map[string]interface{})}
+}
+
+// WithSecret adds the fields in secret to tags
+func (tags Tags) WithSecret(secret *corev1.Secret) Tags {
+	if secret != nil {
+		for n, v := range secret.Data {
+			tags.M[n] = string(v)
+		}
+	}
+	return tags
+}
+
+// With adds obj to tags
+func (tags Tags) With(label string, obj interface{}) Tags {
+	if obj != nil {
+		tags.M[label] = obj
+	}
+	return tags
+}
+
+// WithRecommendedVersionForPromotion
+func (tags Tags) WithRecommendedVersionForPromotion(exp *v2alpha2.Experiment) Tags {
+	if exp == nil || exp.Status.VersionRecommendedForPromotion == nil {
+		log.Warn("no version recommended for promotion")
+		return tags
+	}
+
+	versionRecommendedForPromotion := *exp.Status.VersionRecommendedForPromotion
+	if exp.Spec.VersionInfo == nil {
+		log.Warnf("No version details found for version recommended for promotion: %s", versionRecommendedForPromotion)
+		return tags
+	}
+
+	var versionDetail *v2alpha2.VersionDetail = nil
+	if exp.Spec.VersionInfo.Baseline.Name == versionRecommendedForPromotion {
+		versionDetail = &exp.Spec.VersionInfo.Baseline
+	} else {
+		for _, v := range exp.Spec.VersionInfo.Candidates {
+			if v.Name == versionRecommendedForPromotion {
+				versionDetail = &v
+				break
+			}
+		}
+	}
+	if versionDetail == nil {
+		log.Warnf("No version details found for version recommended for promotion: %s", versionRecommendedForPromotion)
+		return tags
+	}
+
+	// get the variable values from the (recommended) versionDetail
+	tags.M["name"] = versionDetail.Name
+	for _, v := range versionDetail.Variables {
+		tags.M[v.Name] = v.Value
+	}
+
+	return tags
 }
 
 // Interpolate str using tags.

--- a/base/base.go
+++ b/base/base.go
@@ -72,7 +72,7 @@ func (tags Tags) With(label string, obj interface{}) Tags {
 	return tags
 }
 
-// WithRecommendedVersionForPromotion
+// WithRecommendedVersionForPromotion adds variables from versionDetail of version recommended for promotion
 func (tags Tags) WithRecommendedVersionForPromotion(exp *v2alpha2.Experiment) Tags {
 	if exp == nil || exp.Status.VersionRecommendedForPromotion == nil {
 		log.Warn("no version recommended for promotion")

--- a/base/base_test.go
+++ b/base/base_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/iter8-tools/handler/utils"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {
@@ -12,27 +14,58 @@ func init() {
 }
 
 func TestInterpolate(t *testing.T) {
-	tags := Tags{
-		M: map[string]string{"revision": "revision1", "container": "super-container"},
+	tags := NewTags().
+		With("name", "tester").
+		With("revision", "revision1").
+		With("container", "super-container")
+
+	// success cases
+	inputs := []string{
+		// `hello {{index . "name"}}`,
+		// "hello {{index .name}}",
+		"hello {{.name}}",
+		"hello {{.name}}{{.other}}",
 	}
-	str := `hello {{ index . "revision" }} world`
+	for _, str := range inputs {
+		interpolated, err := tags.Interpolate(&str)
+		assert.NoError(t, err)
+		assert.Equal(t, "hello tester", interpolated)
+	}
+
+	// failure cases
+	inputs = []string{
+		// bad braces,
+		"hello {{{index .name}}",
+		// missing '.'
+		"hello {{name}}",
+	}
+	for _, str := range inputs {
+		_, err := tags.Interpolate(&str)
+		assert.Error(t, err)
+	}
+
+	// empty tags (success cases)
+	str := "hello {{.name}}"
+	tags = NewTags()
 	interpolated, err := tags.Interpolate(&str)
 	assert.NoError(t, err)
-	assert.Equal(t, "hello revision1 world", interpolated)
+	assert.Equal(t, "hello ", interpolated)
 
-	tags = Tags{}
+	// secret
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"secretName": []byte("tester"),
+		},
+	}
+
+	str = "hello {{.secretName}}"
+	tags = NewTags().WithSecret(&secret)
+	assert.Contains(t, tags.M, "secretName")
 	interpolated, err = tags.Interpolate(&str)
 	assert.NoError(t, err)
-	assert.Equal(t, str, interpolated)
-
-	tags = Tags{
-		M: map[string]string{"revision": "revision1", "container": "super-container"},
-	}
-	str = `hello {{{ romeo . "revision" alpha tango }} world`
-	_, err = tags.Interpolate(&str)
-	assert.Error(t, err)
-
-	str = `hello {{ index . 0 }} world`
-	_, err = tags.Interpolate(&str)
-	assert.Error(t, err)
+	assert.Equal(t, "hello tester", interpolated)
 }

--- a/base/base_test.go
+++ b/base/base_test.go
@@ -1,8 +1,12 @@
 package base
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
+	"github.com/ghodss/yaml"
+	"github.com/iter8-tools/etc3/api/v2alpha2"
 	"github.com/iter8-tools/handler/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -68,4 +72,15 @@ func TestInterpolate(t *testing.T) {
 	interpolated, err = tags.Interpolate(&str)
 	assert.NoError(t, err)
 	assert.Equal(t, "hello tester", interpolated)
+}
+
+func TestWithVersionRecommendedForPromotion(t *testing.T) {
+	var data []byte
+	data, err := ioutil.ReadFile(filepath.Join("..", "testdata", "experiment1.yaml"))
+	assert.NoError(t, err)
+	exp := &v2alpha2.Experiment{}
+	err = yaml.Unmarshal(data, exp)
+	assert.NoError(t, err)
+	tags := NewTags().WithRecommendedVersionForPromotion(exp)
+	assert.Equal(t, "revision1", tags.M["revision"])
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -40,7 +40,7 @@ Loop:
 	for i := 0; i < len(actionSpec); i++ {
 		if actionSpecSubstr := strings.Split(actionSpec[i].Task, "/"); len(actionSpecSubstr) == 2 {
 			switch actionSpecSubstr[0] {
-			case "common":
+			case common.LibraryName:
 				if action[i], err = common.MakeTask(&actionSpec[i]); err != nil {
 					break Loop
 				}

--- a/experiment/buildfromfile.go
+++ b/experiment/buildfromfile.go
@@ -20,7 +20,9 @@ func (b *Builder) FromFile(filePath string) *Builder {
 			b.exp = exp
 			return b
 		}
+		log.Error(err)
 	}
+	log.Error(err)
 	b.err = errors.New("cannot build experiment from file")
 	return b
 }

--- a/experiment/experiment.go
+++ b/experiment/experiment.go
@@ -3,13 +3,18 @@ package experiment
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/iter8-tools/etc3/api/v2alpha2"
 	iter8 "github.com/iter8-tools/etc3/api/v2alpha2"
 	"github.com/iter8-tools/handler/base"
 	"github.com/iter8-tools/handler/utils"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var log *logrus.Logger
@@ -51,6 +56,7 @@ func GetExperimentFromContext(ctx context.Context) (*Experiment, error) {
 	return nil, errors.New("context has no experiment key")
 }
 
+// DEPRECATED. Use tags.Interpolate in base package instead
 // Interpolate interpolates input arguments based on tags of the version recommended for promotion in the experiment.
 func (exp *Experiment) Interpolate(inputArgs []string) ([]string, error) {
 	var recommendedBaseline string
@@ -60,7 +66,7 @@ func (exp *Experiment) Interpolate(inputArgs []string) ([]string, error) {
 		var versionDetail *iter8.VersionDetail
 		if versionDetail, err = exp.GetVersionDetail(recommendedBaseline); err == nil {
 			// get the tags
-			tags := base.Tags{M: make(map[string]string)}
+			tags := base.Tags{M: make(map[string]interface{})}
 			tags.M["name"] = versionDetail.Name
 			for i := 0; i < len(versionDetail.Variables); i++ {
 				tags.M[versionDetail.Variables[i].Name] = versionDetail.Variables[i].Value
@@ -76,4 +82,41 @@ func (exp *Experiment) Interpolate(inputArgs []string) ([]string, error) {
 		}
 	}
 	return args, err
+}
+
+func (e *Experiment) ToMap() (map[string]interface{}, error) {
+	// convert unstructured object to JSON object
+	expJSON, err := json.Marshal(e)
+	if err != nil {
+		log.Error(err, "Unable to convert experiment to JSON")
+		return nil, err
+	}
+
+	// convert JSON object to Go map
+	expObj := make(map[string]interface{})
+	err = json.Unmarshal(expJSON, &expObj)
+	if err != nil {
+		log.Error(err, "Unable to convert JSON to object")
+		return nil, err
+	}
+	return expObj, nil
+}
+
+// GetSecret retrieves a secret from the kubernetes cluster
+func GetSecret(namespacedname string) (*corev1.Secret, error) {
+	// get secret namespace and name
+	namespace := viper.GetViper().GetString("experiment_namespace")
+	var name string
+	nn := strings.Split(namespacedname, "/")
+	if len(nn) == 1 {
+		name = nn[0]
+	} else {
+		namespace = nn[0]
+		name = nn[1]
+	}
+	log.Trace("getSecret", "namespace", namespace, "name", name)
+
+	secret := corev1.Secret{}
+	err := GetTypedObject(&types.NamespacedName{Namespace: namespace, Name: name}, &secret)
+	return &secret, err
 }

--- a/experiment/experiment.go
+++ b/experiment/experiment.go
@@ -56,8 +56,8 @@ func GetExperimentFromContext(ctx context.Context) (*Experiment, error) {
 	return nil, errors.New("context has no experiment key")
 }
 
-// DEPRECATED. Use tags.Interpolate in base package instead
 // Interpolate interpolates input arguments based on tags of the version recommended for promotion in the experiment.
+// DEPRECATED. Use tags.Interpolate in base package instead
 func (exp *Experiment) Interpolate(inputArgs []string) ([]string, error) {
 	var recommendedBaseline string
 	var args []string
@@ -84,9 +84,10 @@ func (exp *Experiment) Interpolate(inputArgs []string) ([]string, error) {
 	return args, err
 }
 
-func (e *Experiment) ToMap() (map[string]interface{}, error) {
+// ToMap converts exp.Experiment to  a map[string]interface{}
+func (exp *Experiment) ToMap() (map[string]interface{}, error) {
 	// convert unstructured object to JSON object
-	expJSON, err := json.Marshal(e)
+	expJSON, err := json.Marshal(exp.Experiment)
 	if err != nil {
 		log.Error(err, "Unable to convert experiment to JSON")
 		return nil, err

--- a/experiment/experiment_env_test.go
+++ b/experiment/experiment_env_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/iter8-tools/handler/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -84,5 +86,27 @@ var _ = Describe("Experiment's handler field", func() {
 		// 	err = exp.Run("start")
 		// 	Expect(err).To(HaveOccurred())
 		// })
+	})
+})
+
+var _ = Describe("GetSecret", func() {
+	Context("When call GetSecret for a valid secret", func() {
+		It("should read the secret", func() {
+			By("Creating a secret")
+			secret := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"secretName": []byte("tester"),
+				},
+			}
+			k8sClient.Create(context.Background(), &secret)
+			By("Calling GetSecret")
+			s, err := experiment.GetSecret("default/test-secret")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(s.Data["secretName"])).To(Equal("tester"))
+		})
 	})
 })

--- a/experiment/experiment_test.go
+++ b/experiment/experiment_test.go
@@ -95,6 +95,18 @@ func TestInterpolate(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestInterpolateWithExperiment(t *testing.T) {
+	exp, err := (&Builder{}).FromFile(utils.CompletePath("../", "testdata/experiment6.yaml")).Build()
+	assert.NoError(t, err)
+	e, err := exp.ToMap()
+	assert.NoError(t, err)
+	tags := base.NewTags().With("this", e).WithRecommendedVersionForPromotion(&exp.Experiment)
+	str := "{{.this.metadata.namespace}} {{.revision}}"
+	v, err := tags.Interpolate(&str)
+	assert.NoError(t, err)
+	assert.Equal(t, "default revision1", v)
+}
+
 // func TestInterpolateWithoutHandlerStanza(t *testing.T) {
 // 	var e *Experiment = &Experiment{}
 // 	assert.NoError(t, e.interpolate())

--- a/lib/common/bash.go
+++ b/lib/common/bash.go
@@ -1,0 +1,87 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/iter8-tools/etc3/api/v2alpha2"
+	"github.com/iter8-tools/handler/base"
+	"github.com/iter8-tools/handler/experiment"
+)
+
+const (
+	// BashTaskName is the name of the bash task
+	BashTaskName string = "bash"
+)
+
+// BashInputs contain the name and arguments of the command to be executed.
+type BashInputs struct {
+	Script string `json:"script" yaml:"script"`
+}
+
+// BashTask encapsulates a command that can be executed.
+type BashTask struct {
+	base.TaskMeta `json:",inline" yaml:",inline"`
+	With          BashInputs `json:"with" yaml:"with"`
+}
+
+// MakeBashTask converts an exec task spec into an exec task.
+func MakeBashTask(t *v2alpha2.TaskSpec) (base.Task, error) {
+	if t.Task != LibraryName+"/"+BashTaskName {
+		return nil, fmt.Errorf("library and task need to be '%s' and '%s'", LibraryName, BashTaskName)
+	}
+	var jsonBytes []byte
+	var task base.Task
+	// convert t to jsonBytes
+	jsonBytes, err := json.Marshal(t)
+	if err != nil {
+		return nil, err
+	}
+	// convert jsonString to ExecTask
+	task = &BashTask{}
+	err = json.Unmarshal(jsonBytes, &task)
+	return task, err
+}
+
+// Run the command.
+func (t *BashTask) Run(ctx context.Context) error {
+	exp, err := experiment.GetExperimentFromContext(ctx)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	log.Trace("experiment", exp)
+
+	obj, err := exp.ToMap()
+	if err != nil {
+		// error already logged by ToMap()
+		// don't log it again
+		return err
+	}
+
+	// prepare for interpolation; add experiment as tag
+	// Note that if versionRecommendedForPromotion is not set or there is no version corresponding to it,
+	// then some placeholders may not be replaced
+	tags := base.NewTags().
+		With("this", obj).
+		WithRecommendedVersionForPromotion(&exp.Experiment)
+	log.Tracef("tags: %v", tags)
+
+	// interpolate - replaces placeholders in the script with values
+	script, err := tags.Interpolate(&t.With.Script)
+
+	log.Trace(script)
+	args := []string{"-c", script}
+
+	cmd := exec.Command("/bin/bash", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	log.Info("Running task: " + cmd.String())
+	log.Trace(args)
+	err = cmd.Run()
+
+	return err
+}

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -9,6 +9,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// LibraryName is the name of this task library
+	LibraryName string = "common"
+)
+
 var log *logrus.Logger
 
 func init() {
@@ -18,8 +23,10 @@ func init() {
 // MakeTask constructs a Task from a TaskSpec or returns an error if any.
 func MakeTask(t *v2alpha2.TaskSpec) (base.Task, error) {
 	switch t.Task {
-	case "common/exec":
+	case LibraryName + "/" + ExecTaskName:
 		return MakeExec(t)
+	case LibraryName + "/" + BashTaskName:
+		return MakeBashTask(t)
 	default:
 		return nil, errors.New("Unknown task: " + t.Task)
 	}

--- a/lib/common/common_test.go
+++ b/lib/common/common_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/iter8-tools/etc3/api/v2alpha2"
@@ -74,4 +75,17 @@ func TestMakeBashTask(t *testing.T) {
 	assert.NotEmpty(t, task)
 	assert.NoError(t, err)
 	assert.Equal(t, "echo hello", task.(*BashTask).With.Script)
+}
+
+func TestBashRun(t *testing.T) {
+	exp, err := (&experiment.Builder{}).FromFile(filepath.Join("..", "..", "testdata", "common", "bashexperiment.yaml")).Build()
+	assert.NoError(t, err)
+	actionSpec, err := exp.GetActionSpec("start")
+	assert.NoError(t, err)
+	// action, err := GetAction(exp, actionSpec)
+	action, err := MakeTask(&actionSpec[0])
+	assert.NoError(t, err)
+	ctx := context.WithValue(context.Background(), base.ContextKey("experiment"), exp)
+	err = action.Run(ctx)
+	assert.NoError(t, err)
 }

--- a/lib/common/common_test.go
+++ b/lib/common/common_test.go
@@ -62,3 +62,16 @@ func TestExecTaskNoInterpolation(t *testing.T) {
 	exp, err := (&experiment.Builder{}).FromFile(utils.CompletePath("../../", "testdata/experiment10.yaml")).Build()
 	task.Run(context.WithValue(context.Background(), base.ContextKey("experiment"), exp))
 }
+
+func TestMakeBashTask(t *testing.T) {
+	script, _ := json.Marshal("echo hello")
+	task, err := MakeTask(&v2alpha2.TaskSpec{
+		Task: LibraryName + "/" + BashTaskName,
+		With: map[string]apiextensionsv1.JSON{
+			"script": {Raw: script},
+		},
+	})
+	assert.NotEmpty(t, task)
+	assert.NoError(t, err)
+	assert.Equal(t, "echo hello", task.(*BashTask).With.Script)
+}

--- a/lib/common/exec.go
+++ b/lib/common/exec.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +10,11 @@ import (
 	"github.com/iter8-tools/etc3/api/v2alpha2"
 	"github.com/iter8-tools/handler/base"
 	"github.com/iter8-tools/handler/experiment"
+)
+
+const (
+	// ExecTaskName is the name of this file implements
+	ExecTaskName string = "exec"
 )
 
 // ExecInputs contain the name and arguments of the command to be executed.
@@ -22,9 +26,8 @@ type ExecInputs struct {
 
 // ExecTask encapsulates a command that can be executed.
 type ExecTask struct {
-	Library string     `json:"library" yaml:"library"`
-	Task    string     `json:"task" yaml:"task"`
-	With    ExecInputs `json:"with" yaml:"with"`
+	base.TaskMeta `json:",inline" yaml:",inline"`
+	With          ExecInputs `json:"with" yaml:"with"`
 }
 
 // Run the command.
@@ -60,8 +63,8 @@ func (t *ExecTask) Run(ctx context.Context) error {
 
 // MakeExec converts an exec task spec into an exec task.
 func MakeExec(t *v2alpha2.TaskSpec) (base.Task, error) {
-	if t.Task != "common/exec" {
-		return nil, errors.New("library and task need to be 'common' and 'exec'")
+	if t.Task != LibraryName+"/"+ExecTaskName {
+		return nil, fmt.Errorf("library and task need to be '%s' and '%s'", LibraryName, ExecTaskName)
 	}
 	var err error
 	var jsonBytes []byte

--- a/lib/notification/notification.go
+++ b/lib/notification/notification.go
@@ -26,7 +26,7 @@ func MakeTask(t *v2alpha2.TaskSpec) (base.Task, error) {
 	switch t.Task {
 	case LibraryName + "/" + SlackTaskName:
 		return MakeSlackTask(t)
-	// add additional tasks here
+	// add additional tasks here options here
 	default:
 		return nil, errors.New("Unknown task: " + t.Task)
 	}

--- a/lib/notification/notification.go
+++ b/lib/notification/notification.go
@@ -26,7 +26,7 @@ func MakeTask(t *v2alpha2.TaskSpec) (base.Task, error) {
 	switch t.Task {
 	case LibraryName + "/" + SlackTaskName:
 		return MakeSlackTask(t)
-	// add additional tasks here options here
+	// add additional tasks here
 	default:
 		return nil, errors.New("Unknown task: " + t.Task)
 	}

--- a/testdata/common/bashexperiment.yaml
+++ b/testdata/common/bashexperiment.yaml
@@ -1,0 +1,62 @@
+apiVersion: iter8.tools/v2alpha2
+kind: Experiment
+metadata:
+  name: quickstart-exp
+spec:
+  # target identifies the service under experimentation using its fully qualified name
+  target: bookinfo-iter8/productpage
+  strategy:
+    # this experiment will perform an A/B test
+    testingPattern: A/B
+    # this experiment will progressively shift traffic to the winning version
+    deploymentPattern: Progressive
+    actions:
+      # when the experiment completes, promote the winning version using kubectl apply
+      start:
+      - task: common/bash
+        with:
+          script: | 
+            echo "Experiment: {{ .this.metadata.namespace }}/{{ .this.metadata.name }}"
+            echo "{{.promote}}"
+  criteria:
+    rewards:
+    # (business) reward metric to optimize in this experiment
+    - metric: iter8-istio/user-engagement 
+      preferredDirection: High
+    objectives: # used for validating versions
+    - metric: iter8-istio/mean-latency
+      upperLimit: 300
+    - metric: iter8-istio/error-rate
+      upperLimit: "0.01"
+    requestCount: iter8-istio/request-count
+  duration: # product of fields determines length of the experiment
+    intervalSeconds: 10
+    iterationsPerLoop: 5
+  versionInfo:
+    # information about the app versions used in this experiment
+    baseline:
+      name: productpage-v1
+      variables:
+      - name: namespace # used by final action if this version is the winner
+        value: bookinfo-iter8
+      - name: promote # used by final action if this version is the winner
+        value: https://raw.githubusercontent.com/iter8-tools/iter8/master/samples/istio/quickstart/vs-for-v1.yaml
+      weightObjRef:
+        apiVersion: networking.istio.io/v1beta1
+        kind: VirtualService
+        namespace: bookinfo-iter8
+        name: bookinfo
+        fieldPath: .spec.http[0].route[0].weight
+    candidates:
+    - name: productpage-v2
+      variables:
+      - name: namespace # used by final action if this version is the winner
+        value: bookinfo-iter8
+      - name: promote # used by final action if this version is the winner
+        value: https://raw.githubusercontent.com/iter8-tools/iter8/master/samples/istio/quickstart/vs-for-v2.yaml
+      weightObjRef:
+        apiVersion: networking.istio.io/v1beta1
+        kind: VirtualService
+        namespace: bookinfo-iter8
+        name: bookinfo
+        fieldPath: .spec.http[0].route[1].weight

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -13,3 +13,22 @@ func TestMakeTask(t *testing.T) {
 	assert.NotEmpty(t, log)
 	SetLogLevel(logrus.InfoLevel)
 }
+
+func TestGetJsonBytes(t *testing.T) {
+	// valid
+	_, err := GetJSONBytes("https://httpbin.org/stream/1")
+	assert.NoError(t, err)
+
+	// invalid
+	_, err = GetJSONBytes("https://httpbin.org/undef")
+	assert.Error(t, err)
+}
+
+func TestPointers(t *testing.T) {
+	assert.Equal(t, int32(1), *Int32Pointer(1))
+	assert.Equal(t, float32(0.1), *Float32Pointer(0.1))
+	assert.Equal(t, float64(0.1), *Float64Pointer(0.1))
+	assert.Equal(t, "hello", *StringPointer("hello"))
+	assert.Equal(t, false, *BoolPointer(false))
+	assert.Equal(t, GET, *HTTPMethodPointer(GET))
+}


### PR DESCRIPTION
Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>

Fixes https://github.com/iter8-tools/iter8/issues/733 by introducing an experimental task `common/bash` which improves `common/exec` in two ways:

- removes the need to specify `disableInterpolation` in start tasks; this is determined automatically
- eliminates the need to specify the command (`bin/bash`) and the argument `-c`; these are added immediately.

In addition to these changes, some initial support is added for other tasks including interpolation from the experiment (via the label `.this`) and from a secret. Some refactoring was done to support this.

TBD: if we want to promote this task to be generally available, it needs to be documented in place of `common/exec`.
