### PR TITLE
Updated Dockerfile for handler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN linux-amd64/helm version
 # Install Kustomize v3
 RUN curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
 RUN cp kustomize /bin
+RUN GOBIN=/bin go get fortio.org/fortio
 
 # Small linux image with useful shell commands
 FROM debian:buster-slim
@@ -42,6 +43,7 @@ COPY --from=builder /bin/handler /bin/handler
 COPY --from=builder /bin/kubectl /bin/kubectl
 COPY --from=builder /bin/kustomize /bin/kustomize
 COPY --from=builder /workspace/linux-amd64/helm /bin/helm
+COPY --from=builder /bin/fortio /bin/fortio
 
 # Install git
 RUN apt-get update && apt-get install -y git

--- a/lib/metrics/collect.go
+++ b/lib/metrics/collect.go
@@ -382,13 +382,13 @@ func (t *CollectTask) Run(ctx context.Context) error {
 
 	bytes1, _ := json.MarshalIndent(exp, "", "  ")
 	log.Trace("Experiment with updated status... before the update call")
-	log.Trace(bytes1)
+	log.Trace(string(bytes1))
 
 	err = experiment.UpdateInClusterExperimentStatus(exp)
 
 	bytes2, _ := json.MarshalIndent(exp, "", "  ")
 	log.Trace("Experiment with updated status... after the update call")
-	log.Trace(bytes2)
+	log.Trace(string(bytes2))
 
 	return err
 }

--- a/lib/metrics/collect.go
+++ b/lib/metrics/collect.go
@@ -379,5 +379,16 @@ func (t *CollectTask) Run(ctx context.Context) error {
 		return err
 	}
 	exp.SetAggregatedBuiltinHists(v1.JSON{Raw: bytes})
-	return experiment.UpdateInClusterExperimentStatus(exp)
+
+	bytes1, _ := json.MarshalIndent(exp, "", "  ")
+	log.Trace("Experiment with updated status... before the update call")
+	log.Trace(bytes1)
+
+	err = experiment.UpdateInClusterExperimentStatus(exp)
+
+	bytes2, _ := json.MarshalIndent(exp, "", "  ")
+	log.Trace("Experiment with updated status... after the update call")
+	log.Trace(bytes2)
+
+	return err
 }

--- a/lib/metrics/collect_test.go
+++ b/lib/metrics/collect_test.go
@@ -107,7 +107,7 @@ func TestPayloadFile(t *testing.T) {
 	assert.Empty(t, fileName)
 }
 
-func TestResultForVersionresultForVersion(t *testing.T) {
+func TestResultForVersion(t *testing.T) {
 	ct := CollectTask{
 		Library: "metrics",
 		Task:    "collect",

--- a/lib/metrics/collect_test.go
+++ b/lib/metrics/collect_test.go
@@ -119,7 +119,8 @@ func TestResultForVersionresultForVersion(t *testing.T) {
 		},
 	}
 	ct.InitializeDefaults()
-	res, err := ct.resultForVersion(0, "")
+	entry := log.WithField("version", "default")
+	res, err := ct.resultForVersion(entry, 0, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
 }

--- a/lib/metrics/metrics_test.go
+++ b/lib/metrics/metrics_test.go
@@ -1,18 +1,38 @@
 package metrics
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/iter8-tools/etc3/api/v2alpha2"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func TestMakeTask(t *testing.T) {
+	vers, err := json.Marshal([]Version{
+		{
+			Name: "test",
+			URL:  "https://iter8.tools",
+		},
+	})
 	task, err := MakeTask(&v2alpha2.TaskSpec{
 		Task: "metrics/collect",
+		With: map[string]v1.JSON{
+			"versions": {Raw: vers},
+		},
 	})
 	assert.NotEmpty(t, task)
 	assert.NoError(t, err)
+
+	task, err = MakeTask(&v2alpha2.TaskSpec{
+		Task: "metrics/collect",
+		With: map[string]v1.JSON{
+			"versionables": {Raw: vers},
+		},
+	})
+	assert.Empty(t, task)
+	assert.Error(t, err)
 
 	task, err = MakeTask(&v2alpha2.TaskSpec{
 		Task: "metrics/collect-it",

--- a/testdata/metricscollect/loadgen.yaml
+++ b/testdata/metricscollect/loadgen.yaml
@@ -1,0 +1,44 @@
+apiVersion: iter8.tools/v2alpha2
+kind: Experiment
+metadata: 
+  generation: 1
+  name: loadgen-exp
+  namespace: default
+spec:
+  duration:
+    intervalSeconds: 15
+    iterationsPerLoop: 10
+  versionInfo:
+    baseline:
+      name: default
+      variables:
+      - name: revision
+        value: revision1
+    candidates:
+    - name: canary
+      variables:
+      - name: revision
+        value: revision2
+      weightObjRef:
+        apiVersion: serving.kubeflow.org/v1alpha2
+        fieldPath: .spec.canaryTrafficPercent
+        kind: InferenceService
+        name: sklearn-iris
+        namespace: default
+  strategy:
+    actions:
+      start:
+      - task: metrics/collect
+        with:
+          loadOnly: true
+          versions:
+          - name: default
+            url: https://httpbin.org
+          - name: canary
+            url: https://httpbin.org/stream/1
+    testingPattern: Canary
+    deploymentPattern: Progressive
+    weights: 
+      maxCandidateWeight: 100
+      maxCandidateWeightIncrement: 10
+  target: default/sklearn-iris

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -29,6 +29,9 @@ func GetLogger() *logrus.Logger {
 	if log == nil {
 		log = logrus.New()
 		log.SetLevel(logLevel)
+		log.SetFormatter(&logrus.TextFormatter{
+			DisableQuote: true,
+		})
 	}
 	return log
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -59,6 +59,11 @@ func StringPointer(s string) *string {
 	return &s
 }
 
+// BoolPointer takes a bool as input, creates a new variable with the input value, and returns a pointer to the variable
+func BoolPointer(b bool) *bool {
+	return &b
+}
+
 // HTTPMethod is either GET or POST
 type HTTPMethod string
 


### PR DESCRIPTION
Partly addresses iter8-tools/iter8#684

The Dockerfile should have been updated earlier as part of [this PR](https://github.com/iter8-tools/handler/pull/29) but I had forgotten to change it. Here it is.

I am currently testing with [my personal repo image](https://github.com/sriumcp/iter8/blob/636bdbe0c424f727e4eef2197508ef5d2b247644/install/core/iter8-handler/handler.yaml#L12) to make the Iter8 CI succeed... will update my Iter8 PR as soon as this handler PR is merged and new image is created.