### PR TITLE
refactor so can create base.GetDefaultTags

### DIFF
--- a/base/base_test.go
+++ b/base/base_test.go
@@ -1,98 +1,65 @@
 package base
 
 import (
-	"io/ioutil"
-	"path/filepath"
+	"context"
 	"testing"
 
-	"github.com/ghodss/yaml"
-	"github.com/iter8-tools/etc3/api/v2alpha2"
+	"github.com/iter8-tools/handler/experiment"
 	"github.com/iter8-tools/handler/utils"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {
 	log = utils.GetLogger()
 }
 
-func TestInterpolate(t *testing.T) {
-	tags := NewTags().
-		With("name", "tester").
-		With("revision", "revision1").
-		With("container", "super-container")
+// func TestWithVersionRecommendedForPromotion(t *testing.T) {
+// 	var data []byte
+// 	data, err := ioutil.ReadFile(filepath.Join("..", "testdata", "experiment1.yaml"))
+// 	assert.NoError(t, err)
+// 	exp := &v2alpha2.Experiment{}
+// 	err = yaml.Unmarshal(data, exp)
+// 	assert.NoError(t, err)
+// 	tags := interpolation.NewTags().WithRecommendedVersionForPromotion(exp)
+// 	assert.Equal(t, "revision1", tags.M["revision"])
+// }
 
-	// success cases
-	inputs := []string{
-		// `hello {{index . "name"}}`,
-		// "hello {{index .name}}",
-		"hello {{.name}}",
-		"hello {{.name}}{{.other}}",
+// func TestWithOutVersionRecommendedForPromotion(t *testing.T) {
+// 	var data []byte
+// 	data, err := ioutil.ReadFile(filepath.Join("..", "testdata", "experiment1-norecommended.yaml"))
+// 	assert.NoError(t, err)
+// 	exp := &v2alpha2.Experiment{}
+// 	err = yaml.Unmarshal(data, exp)
+// 	assert.NoError(t, err)
+// 	tags := interpolation.NewTags().WithRecommendedVersionForPromotion(exp)
+// 	assert.NotContains(t, tags.M, "revision1")
+// 	// assert.Equal(t, "revision1", tags.M["revision"])
+// }
+
+func TestWithExperiment(t *testing.T) {
+	exp, err := (&experiment.Builder{}).FromFile(utils.CompletePath("../", "testdata/experiment1.yaml")).Build()
+	assert.NoError(t, err)
+	ctx := context.WithValue(context.Background(), utils.ContextKey("experiment"), exp)
+	tags := GetDefaultTags(ctx)
+
+	testStr := []string{
+		"{{.this.apiVersion}}",
+		"{{.this.metadata.name}}",
+		"{{.this.spec.duration.intervalSeconds}}",
+		"{{(index .this.spec.versionInfo.baseline.variables 0).value}}",
+		"{{.this.status.versionRecommendedForPromotion}}",
 	}
-	for _, str := range inputs {
-		interpolated, err := tags.Interpolate(&str)
+	expectedOut := []string{
+		"iter8.tools/v2alpha2",
+		"sklearn-iris-experiment-1",
+		"15",
+		"revision1",
+		"default",
+	}
+
+	for i, in := range testStr {
+		out, err := tags.Interpolate(&in)
 		assert.NoError(t, err)
-		assert.Equal(t, "hello tester", interpolated)
+		assert.Equal(t, expectedOut[i], out)
 	}
-
-	// failure cases
-	inputs = []string{
-		// bad braces,
-		"hello {{{index .name}}",
-		// missing '.'
-		"hello {{name}}",
-	}
-	for _, str := range inputs {
-		_, err := tags.Interpolate(&str)
-		assert.Error(t, err)
-	}
-
-	// empty tags (success cases)
-	str := "hello {{.name}}"
-	tags = NewTags()
-	interpolated, err := tags.Interpolate(&str)
-	assert.NoError(t, err)
-	assert.Equal(t, "hello ", interpolated)
-
-	// secret
-	secret := corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "secret",
-			Namespace: "default",
-		},
-		Data: map[string][]byte{
-			"secretName": []byte("tester"),
-		},
-	}
-
-	str = "hello {{.secretName}}"
-	tags = NewTags().WithSecret(&secret)
-	assert.Contains(t, tags.M, "secretName")
-	interpolated, err = tags.Interpolate(&str)
-	assert.NoError(t, err)
-	assert.Equal(t, "hello tester", interpolated)
-}
-
-func TestWithVersionRecommendedForPromotion(t *testing.T) {
-	var data []byte
-	data, err := ioutil.ReadFile(filepath.Join("..", "testdata", "experiment1.yaml"))
-	assert.NoError(t, err)
-	exp := &v2alpha2.Experiment{}
-	err = yaml.Unmarshal(data, exp)
-	assert.NoError(t, err)
-	tags := NewTags().WithRecommendedVersionForPromotion(exp)
-	assert.Equal(t, "revision1", tags.M["revision"])
-}
-
-func TestWithOutVersionRecommendedForPromotion(t *testing.T) {
-	var data []byte
-	data, err := ioutil.ReadFile(filepath.Join("..", "testdata", "experiment1-norecommended.yaml"))
-	assert.NoError(t, err)
-	exp := &v2alpha2.Experiment{}
-	err = yaml.Unmarshal(data, exp)
-	assert.NoError(t, err)
-	tags := NewTags().WithRecommendedVersionForPromotion(exp)
-	assert.NotContains(t, tags.M, "revision1")
-	// assert.Equal(t, "revision1", tags.M["revision"])
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iter8-tools/handler/lib/knative"
 	"github.com/iter8-tools/handler/lib/metrics"
 	"github.com/iter8-tools/handler/lib/notification"
+	"github.com/iter8-tools/handler/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/types"
@@ -77,7 +78,7 @@ func run(cmd *cobra.Command, args []string) error {
 			if actionSpec, err = exp.GetActionSpec(action); err == nil {
 				var action base.Action
 				if action, err = GetAction(exp, actionSpec); err == nil {
-					ctx := context.WithValue(context.Background(), base.ContextKey("experiment"), exp)
+					ctx := context.WithValue(context.Background(), utils.ContextKey("experiment"), exp)
 					log.Trace("created context for experiment")
 					err = action.Run(ctx)
 					if err == nil {

--- a/experiment/experiment.go
+++ b/experiment/experiment.go
@@ -8,8 +8,7 @@ import (
 	"strings"
 
 	"github.com/iter8-tools/etc3/api/v2alpha2"
-	iter8 "github.com/iter8-tools/etc3/api/v2alpha2"
-	"github.com/iter8-tools/handler/base"
+	"github.com/iter8-tools/handler/interpolation"
 	"github.com/iter8-tools/handler/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -44,7 +43,7 @@ func (b *Builder) Build() (*Experiment, error) {
 // GetExperimentFromContext gets the experiment object from given context.
 func GetExperimentFromContext(ctx context.Context) (*Experiment, error) {
 	//	ctx := context.WithValue(context.Background(), base.ContextKey("experiment"), e)
-	if v := ctx.Value(base.ContextKey("experiment")); v != nil {
+	if v := ctx.Value(utils.ContextKey("experiment")); v != nil {
 		log.Debug("found experiment")
 		var e *Experiment
 		var ok bool
@@ -63,10 +62,10 @@ func (exp *Experiment) Interpolate(inputArgs []string) ([]string, error) {
 	var args []string
 	var err error
 	if recommendedBaseline, err = exp.GetVersionRecommendedForPromotion(); err == nil {
-		var versionDetail *iter8.VersionDetail
+		var versionDetail *v2alpha2.VersionDetail
 		if versionDetail, err = exp.GetVersionDetail(recommendedBaseline); err == nil {
 			// get the tags
-			tags := base.Tags{M: make(map[string]interface{})}
+			tags := interpolation.Tags{M: make(map[string]interface{})}
 			tags.M["name"] = versionDetail.Name
 			for i := 0; i < len(versionDetail.Variables); i++ {
 				tags.M[versionDetail.Variables[i].Name] = versionDetail.Variables[i].Value

--- a/experiment/experiment_test.go
+++ b/experiment/experiment_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/iter8-tools/etc3/api/v2alpha2"
-	"github.com/iter8-tools/handler/base"
+	"github.com/iter8-tools/handler/interpolation"
 	"github.com/iter8-tools/handler/utils"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,14 +52,14 @@ func TestGetRecommendedBaseline(t *testing.T) {
 }
 
 func TestGetExperimentFromContext(t *testing.T) {
-	ctx := context.WithValue(context.Background(), base.ContextKey("experiment"), "hello world")
+	ctx := context.WithValue(context.Background(), utils.ContextKey("experiment"), "hello world")
 	_, err := GetExperimentFromContext(ctx)
 	assert.Error(t, err)
 
 	_, err = GetExperimentFromContext(context.Background())
 	assert.Error(t, err)
 
-	ctx = context.WithValue(context.Background(), base.ContextKey("experiment"), &Experiment{
+	ctx = context.WithValue(context.Background(), utils.ContextKey("experiment"), &Experiment{
 		Experiment: v2alpha2.Experiment{
 			TypeMeta:   v1.TypeMeta{},
 			ObjectMeta: v1.ObjectMeta{},
@@ -100,7 +100,7 @@ func TestInterpolateWithExperiment(t *testing.T) {
 	assert.NoError(t, err)
 	e, err := exp.ToMap()
 	assert.NoError(t, err)
-	tags := base.NewTags().With("this", e).WithRecommendedVersionForPromotion(&exp.Experiment)
+	tags := interpolation.NewTags().With("this", e).WithRecommendedVersionForPromotion(&exp.Experiment)
 	str := "{{.this.metadata.namespace}} {{.revision}}"
 	v, err := tags.Interpolate(&str)
 	assert.NoError(t, err)

--- a/interpolation/tags.go
+++ b/interpolation/tags.go
@@ -1,0 +1,103 @@
+package interpolation
+
+import (
+	"bytes"
+	"errors"
+	"html/template"
+
+	"github.com/iter8-tools/etc3/api/v2alpha2"
+	"github.com/iter8-tools/handler/utils"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var log *logrus.Logger
+
+func init() {
+	log = utils.GetLogger()
+}
+
+// Tags supports string extrapolation using tags.
+type Tags struct {
+	M map[string]interface{}
+}
+
+// NewTags creates an empty instance of Tags
+func NewTags() Tags {
+	return Tags{M: make(map[string]interface{})}
+}
+
+// WithSecret adds the fields in secret to tags
+func (tags Tags) WithSecret(secret *corev1.Secret) Tags {
+	if secret != nil {
+		for n, v := range secret.Data {
+			tags.M[n] = string(v)
+		}
+	}
+	return tags
+}
+
+// With adds obj to tags
+func (tags Tags) With(label string, obj interface{}) Tags {
+	if obj != nil {
+		tags.M[label] = obj
+	}
+	return tags
+}
+
+// WithRecommendedVersionForPromotion adds variables from versionDetail of version recommended for promotion
+func (tags Tags) WithRecommendedVersionForPromotion(exp *v2alpha2.Experiment) Tags {
+	if exp == nil || exp.Status.VersionRecommendedForPromotion == nil {
+		log.Warn("no version recommended for promotion")
+		return tags
+	}
+
+	versionRecommendedForPromotion := *exp.Status.VersionRecommendedForPromotion
+	if exp.Spec.VersionInfo == nil {
+		log.Warnf("No version details found for version recommended for promotion: %s", versionRecommendedForPromotion)
+		return tags
+	}
+
+	var versionDetail *v2alpha2.VersionDetail = nil
+	if exp.Spec.VersionInfo.Baseline.Name == versionRecommendedForPromotion {
+		versionDetail = &exp.Spec.VersionInfo.Baseline
+	} else {
+		for _, v := range exp.Spec.VersionInfo.Candidates {
+			if v.Name == versionRecommendedForPromotion {
+				versionDetail = &v
+				break
+			}
+		}
+	}
+	if versionDetail == nil {
+		log.Warnf("No version details found for version recommended for promotion: %s", versionRecommendedForPromotion)
+		return tags
+	}
+
+	// get the variable values from the (recommended) versionDetail
+	tags.M["name"] = versionDetail.Name
+	for _, v := range versionDetail.Variables {
+		tags.M[v.Name] = v.Value
+	}
+
+	return tags
+}
+
+// Interpolate str using tags.
+func (tags *Tags) Interpolate(str *string) (string, error) {
+	if tags == nil || tags.M == nil { // return a copy of the string
+		return *str, nil
+	}
+	var err error
+	var templ *template.Template
+	if templ, err = template.New("").Parse(*str); err == nil {
+		buf := bytes.Buffer{}
+		if err = templ.Execute(&buf, tags.M); err == nil {
+			return string(buf.Bytes()), nil
+		}
+		log.Error("template execution error: ", err)
+		return "", errors.New("cannot interpolate string")
+	}
+	log.Error("template creation error: ", err)
+	return "", errors.New("cannot interpolate string")
+}

--- a/interpolation/tags_test.go
+++ b/interpolation/tags_test.go
@@ -1,0 +1,94 @@
+package interpolation_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/iter8-tools/etc3/api/v2alpha2"
+	"github.com/iter8-tools/handler/interpolation"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInterpolate(t *testing.T) {
+	tags := interpolation.NewTags().
+		With("name", "tester").
+		With("revision", "revision1").
+		With("container", "super-container")
+
+	// success cases
+	inputs := []string{
+		// `hello {{index . "name"}}`,
+		// "hello {{index .name}}",
+		"hello {{.name}}",
+		"hello {{.name}}{{.other}}",
+	}
+	for _, str := range inputs {
+		interpolated, err := tags.Interpolate(&str)
+		assert.NoError(t, err)
+		assert.Equal(t, "hello tester", interpolated)
+	}
+
+	// failure cases
+	inputs = []string{
+		// bad braces,
+		"hello {{{index .name}}",
+		// missing '.'
+		"hello {{name}}",
+	}
+	for _, str := range inputs {
+		_, err := tags.Interpolate(&str)
+		assert.Error(t, err)
+	}
+
+	// empty tags (success cases)
+	str := "hello {{.name}}"
+	tags = interpolation.NewTags()
+	interpolated, err := tags.Interpolate(&str)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello ", interpolated)
+
+	// secret
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"secretName": []byte("tester"),
+		},
+	}
+
+	str = "hello {{.secretName}}"
+	tags = interpolation.NewTags().WithSecret(&secret)
+	assert.Contains(t, tags.M, "secretName")
+	interpolated, err = tags.Interpolate(&str)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello tester", interpolated)
+}
+
+func TestWithVersionRecommendedForPromotion(t *testing.T) {
+	var data []byte
+	data, err := ioutil.ReadFile(filepath.Join("..", "testdata", "experiment1.yaml"))
+	assert.NoError(t, err)
+	exp := &v2alpha2.Experiment{}
+	err = yaml.Unmarshal(data, exp)
+	assert.NoError(t, err)
+	tags := interpolation.NewTags().WithRecommendedVersionForPromotion(exp)
+	assert.Equal(t, "revision1", tags.M["revision"])
+}
+
+func TestWithOutVersionRecommendedForPromotion(t *testing.T) {
+	var data []byte
+	data, err := ioutil.ReadFile(filepath.Join("..", "testdata", "experiment1-norecommended.yaml"))
+	assert.NoError(t, err)
+	exp := &v2alpha2.Experiment{}
+	err = yaml.Unmarshal(data, exp)
+	assert.NoError(t, err)
+	tags := interpolation.NewTags().WithRecommendedVersionForPromotion(exp)
+	assert.NotContains(t, tags.M, "revision1")
+	// assert.Equal(t, "revision1", tags.M["revision"])
+}

--- a/lib/common/bash.go
+++ b/lib/common/bash.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iter8-tools/etc3/api/v2alpha2"
 	"github.com/iter8-tools/handler/base"
 	"github.com/iter8-tools/handler/experiment"
+	"github.com/iter8-tools/handler/interpolation"
 )
 
 const (
@@ -65,7 +66,7 @@ func (t *BashTask) Run(ctx context.Context) error {
 	// prepare for interpolation; add experiment as tag
 	// Note that if versionRecommendedForPromotion is not set or there is no version corresponding to it,
 	// then some placeholders may not be replaced
-	tags := base.NewTags().
+	tags := interpolation.NewTags().
 		With("this", obj).
 		WithRecommendedVersionForPromotion(&exp.Experiment)
 	log.Tracef("tags: %v", tags)

--- a/lib/common/common_test.go
+++ b/lib/common/common_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/iter8-tools/etc3/api/v2alpha2"
-	"github.com/iter8-tools/handler/base"
 	"github.com/iter8-tools/handler/experiment"
 	"github.com/iter8-tools/handler/utils"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +29,7 @@ func TestMakeTask(t *testing.T) {
 	log.Trace(task.(*ExecTask).With.Args)
 
 	exp, err := (&experiment.Builder{}).FromFile(utils.CompletePath("../../", "testdata/experiment10.yaml")).Build()
-	task.Run(context.WithValue(context.Background(), base.ContextKey("experiment"), exp))
+	task.Run(context.WithValue(context.Background(), utils.ContextKey("experiment"), exp))
 
 	task, err = MakeTask(&v2alpha2.TaskSpec{
 		Task: "common/run",
@@ -61,7 +60,7 @@ func TestExecTaskNoInterpolation(t *testing.T) {
 	log.Trace(task.(*ExecTask).With.Args)
 
 	exp, err := (&experiment.Builder{}).FromFile(utils.CompletePath("../../", "testdata/experiment10.yaml")).Build()
-	task.Run(context.WithValue(context.Background(), base.ContextKey("experiment"), exp))
+	task.Run(context.WithValue(context.Background(), utils.ContextKey("experiment"), exp))
 }
 
 func TestMakeBashTask(t *testing.T) {
@@ -85,7 +84,7 @@ func TestBashRun(t *testing.T) {
 	// action, err := GetAction(exp, actionSpec)
 	action, err := MakeTask(&actionSpec[0])
 	assert.NoError(t, err)
-	ctx := context.WithValue(context.Background(), base.ContextKey("experiment"), exp)
+	ctx := context.WithValue(context.Background(), utils.ContextKey("experiment"), exp)
 	err = action.Run(ctx)
 	assert.NoError(t, err)
 }

--- a/lib/knative/knative_env_test.go
+++ b/lib/knative/knative_env_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/iter8-tools/etc3/api/v2alpha2"
-	"github.com/iter8-tools/handler/base"
 	"github.com/iter8-tools/handler/experiment"
 	"github.com/iter8-tools/handler/utils"
 	. "github.com/onsi/ginkgo"
@@ -65,7 +64,7 @@ var _ = Describe("Knative library", func() {
 			}, exp2)).To(Succeed())
 
 			By("populating context with the experiment")
-			ctx := context.WithValue(context.Background(), base.ContextKey("experiment"), exp2)
+			ctx := context.WithValue(context.Background(), utils.ContextKey("experiment"), exp2)
 
 			By("creating an init-experiment task")
 			initExp := InitExperimentTask{
@@ -120,7 +119,7 @@ var _ = Describe("Knative library", func() {
 			}, exp2)).To(Succeed())
 
 			By("populating context with the experiment")
-			ctx := context.WithValue(context.Background(), base.ContextKey("experiment"), exp2)
+			ctx := context.WithValue(context.Background(), utils.ContextKey("experiment"), exp2)
 
 			By("creating an init-experiment task")
 			initExp := InitExperimentTask{

--- a/lib/metrics/metrics_env_test.go
+++ b/lib/metrics/metrics_env_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 
 	"github.com/iter8-tools/etc3/api/v2alpha2"
-	"github.com/iter8-tools/handler/base"
 	"github.com/iter8-tools/handler/experiment"
 	"github.com/iter8-tools/handler/utils"
 	. "github.com/onsi/ginkgo"
@@ -42,7 +41,7 @@ var _ = Describe("metrics library", func() {
 			}, exp2)).To(Succeed())
 
 			By("populating context with the experiment")
-			ctx := context.WithValue(context.Background(), base.ContextKey("experiment"), exp2)
+			ctx := context.WithValue(context.Background(), utils.ContextKey("experiment"), exp2)
 
 			By("creating a metrics/collect task")
 			ct := CollectTask{
@@ -117,7 +116,7 @@ var _ = Describe("metrics library", func() {
 			}, exp2)).To(Succeed())
 
 			By("populating context with the experiment")
-			ctx := context.WithValue(context.Background(), base.ContextKey("experiment"), exp2)
+			ctx := context.WithValue(context.Background(), utils.ContextKey("experiment"), exp2)
 
 			By("creating a metrics/collect task")
 			ct := CollectTask{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -36,6 +36,9 @@ func GetLogger() *logrus.Logger {
 	return log
 }
 
+// ContextKey is the type of key that will be used to index into context.
+type ContextKey string
+
 // CompletePath determines complete path of a file
 var CompletePath func(prefix string, suffix string) string = iter8utils.CompletePath
 


### PR DESCRIPTION
Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>

Addresses issue https://github.com/iter8-tools/iter8/issues/827 by refactoring tags to their own package (interpolation) and moving the definition of type ContextKey (to utils).

Replaces https://github.com/iter8-tools/handler/pull/37 which was more complex