### PR TITLE
adding scratch space for use in run scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ COPY --from=builder /bin/kustomize /bin/kustomize
 COPY --from=builder /workspace/linux-amd64/helm /bin/helm
 COPY --from=builder /bin/fortio /bin/fortio
 COPY --from=builder /bin/yq /bin/yq
+RUN mkdir /scratch
 
 # Install git
 RUN apt-get update && apt-get install -y git

--- a/tasks/runscript/runscript_test.go
+++ b/tasks/runscript/runscript_test.go
@@ -96,3 +96,23 @@ func TestRunFive(t *testing.T) {
 	log.Error(err)
 	assert.Error(t, err)
 }
+
+func TestRunEnv(t *testing.T) {
+
+	exp, err := (&core.Builder{}).FromFile(core.CompletePath("../../testdata/common", "runexperiment.yaml")).Build()
+	assert.NoError(t, err)
+
+	task, err := Make(&v2alpha2.TaskSpec{
+		Run: core.StringPointer("echo $SCRATCH_DIR"),
+	})
+	assert.NoError(t, err)
+	ctx := context.WithValue(context.Background(), core.ContextKey("experiment"), exp)
+
+	cmd, err := task.(*Task).getCommand(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "/bin/bash -c echo $SCRATCH_DIR", cmd.String())
+
+	out, err := cmd.CombinedOutput()
+	assert.Equal(t, "/scratch\n", string(out))
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Signed-off-by: Srinivasan Parthasarathy <spartha@us.ibm.com>

Addresses the scratch dir requirement  in https://github.com/iter8-tools/iter8/issues/960
